### PR TITLE
Fix errors with scala 3.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.17, 2.13.10, 3.2.2]
+        scala: [2.12.17, 2.13.10, 3.3.0]
         java: [temurin@11]
     runs-on: ${{ matrix.os }}
     steps:
@@ -79,7 +79,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [3.2.2]
+        scala: [3.3.0]
         java: [temurin@11]
     runs-on: ${{ matrix.os }}
     steps:
@@ -127,12 +127,12 @@ jobs:
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (3.2.2)
+      - name: Download target directories (3.3.0)
         uses: actions/download-artifact@v2
         with:
-          name: target-${{ matrix.os }}-3.2.2-${{ matrix.java }}
+          name: target-${{ matrix.os }}-3.3.0-${{ matrix.java }}
 
-      - name: Inflate target directories (3.2.2)
+      - name: Inflate target directories (3.3.0)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ homepage := Some(url("http://sangria-graphql.org"))
 licenses := Seq(
   "Apache License, ASL Version 2.0" → url("http://www.apache.org/licenses/LICENSE-2.0"))
 
-ThisBuild / crossScalaVersions := Seq("2.12.17", "2.13.10", "3.2.2")
+ThisBuild / crossScalaVersions := Seq("2.12.17", "2.13.10", "3.3.0")
 ThisBuild / scalaVersion := crossScalaVersions.value.last
 ThisBuild / githubWorkflowPublishTargetBranches := List()
 ThisBuild / githubWorkflowBuildPreamble ++= List(


### PR DESCRIPTION
It looks like previously I unknowingly had taken a shortcut while implementing certain anonymous functions, triggering the macro-check option to fail when upgrading scala 3.3.0. This PR fixes the error.